### PR TITLE
Add `lxml` and dependency minimum versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-requests
+lxml>=4.2.1
+requests>=2.18.4


### PR DESCRIPTION
```
$ python3 -m badlinkfinder --help
Traceback (most recent call last):
....
ModuleNotFoundError: No module named 'lxml'
```