### PR TITLE
Modularize `crawler` and related modules

### DIFF
--- a/badlinkfinder/core.py
+++ b/badlinkfinder/core.py
@@ -1,17 +1,32 @@
 #!/usr/bin/env python3
 # coding: utf-8
 
-from badlinkfinder import __version__ as blf_version
+import logging
+
 from badlinkfinder.cli import parser, extra_parse_logic
 from badlinkfinder.crawler import Crawler
+from badlinkfinder.engine import Engine
 
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+logger.addHandler(logging.StreamHandler())
 
 def main():
     args = extra_parse_logic(parser.parse_args())
 
+    if args.verbosity == 4:
+        logger.setLevel(logging.DEBUG)
+
     try:
         crawler = Crawler(args)
-        errors = crawler.run(args.url)
+        engine = Engine(crawler=crawler, url=args.url)
+
+        engine.main()
+
+        errors = engine.get_errors()
+
+        #errors = engine.crawler.run(args.url)
+
     except KeyboardInterrupt:
         # Catch Interrupt and save progress in case you want to restart it. (TODO)
         sys.exit('\nERROR: Interrupted by user')
@@ -29,3 +44,6 @@ def main():
             print('\nHere are the issues that were found:')
             for error in errors:
                 print(error)
+
+if __name__ == "__main__":
+    main()

--- a/badlinkfinder/engine.py
+++ b/badlinkfinder/engine.py
@@ -1,0 +1,41 @@
+
+
+# The `Engine` does all of the heavy lifting and orchistration of the `Crawler`.
+
+
+import logging
+from urllib.parse import urlparse
+
+import badlinkfinder.sitegraph as sg
+from badlinkfinder.taskqueue import TaskQueue
+
+log = logging.getLogger('Engine')
+
+
+class Engine:
+
+    def __init__(self, crawler, url, sitegraph=None, crawler_threads=8):
+        self.crawler = crawler
+        self.sitegraph = sitegraph
+        self.url = url
+
+        if not sitegraph:
+            self.sitegraph = sg.SiteGraph()
+
+        self.queue = TaskQueue(crawler_threads)
+
+        # Hack these in for now
+        self.crawler.queue = self.queue
+        self.crawler.sitegraph = self.sitegraph
+
+        self.crawler.domain = urlparse(self.url).netloc
+
+    def main(self):
+        response = self.crawler.retrieve(self.url)
+
+        log.debug('Adding crawler object to queue for url: ' + response.url)
+        self.queue.add_task(self.crawler.crawl, response.url)
+        self.queue.join()
+
+    def get_errors(self):
+        return self.crawler.errors


### PR DESCRIPTION
The current badlinkfinder has tightly coupled objects and complex threading logic.  This is an initial attempt to reduce the complexity of the _Crawler_ into a simple http library and build out an _engine_ that is responsible for orchestrating the stateful components (such as the graph, queue) and the items that should not be stateful (crawler).

This also uses a 'dependency injection' pattern to facilitate testing later on by being able to inject 'mock' modules and test functionality.  
